### PR TITLE
docs: add API reference pages and fix sphinx config

### DIFF
--- a/docs/api/evolution.rst
+++ b/docs/api/evolution.rst
@@ -1,0 +1,63 @@
+qalma.evolution
+===============
+
+.. automodule:: qalma.evolution
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Simulation object
+-----------------
+
+.. automodule:: qalma.evolution.simulation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+MaxEnt projected evolution
+--------------------------
+
+.. automodule:: qalma.evolution.maxent_evol
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Hierarchical basis
+------------------
+
+.. automodule:: qalma.evolution.hierarchical_basis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Heisenberg solver
+-----------------
+
+.. automodule:: qalma.evolution.heisenberg_solver
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Series expansion solver
+-----------------------
+
+.. automodule:: qalma.evolution.series_solver
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+QuTiP solver interface
+-----------------------
+
+.. automodule:: qalma.evolution.qutip_solver
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Tools
+-----
+
+.. automodule:: qalma.evolution.tools
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/meanfield.rst
+++ b/docs/api/meanfield.rst
@@ -1,0 +1,39 @@
+qalma.meanfield
+===============
+
+.. automodule:: qalma.meanfield
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Mean-field projection
+---------------------
+
+.. automodule:: qalma.meanfield.meanfield
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Self-consistent projections
+---------------------------
+
+.. automodule:: qalma.meanfield.self_consistent_projections
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Variational mean field
+----------------------
+
+.. automodule:: qalma.meanfield.variational
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Gibbs partial trace
+-------------------
+
+.. automodule:: qalma.meanfield.gibbs_partial_trace
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,16 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 1
+
+   qalma
+   operators
+   operators.functions
+   operators.states
+   operators.quadratic
+   evolution
+   meanfield
+   scalarprod
+   projections
+   qutip_tools

--- a/docs/api/operators.functions.rst
+++ b/docs/api/operators.functions.rst
@@ -1,0 +1,39 @@
+qalma.operators.functions
+=========================
+
+.. automodule:: qalma.operators.functions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Commutators
+-----------
+
+.. automodule:: qalma.operators.functions.commutators
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Spectral functions
+------------------
+
+.. automodule:: qalma.operators.functions.spectral
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Hermiticity
+-----------
+
+.. automodule:: qalma.operators.functions.hermiticity
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Fidelity
+--------
+
+.. automodule:: qalma.operators.functions.fidelity
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/operators.quadratic.rst
+++ b/docs/api/operators.quadratic.rst
@@ -1,0 +1,23 @@
+qalma.operators.quadratic
+=========================
+
+.. automodule:: qalma.operators.quadratic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+QuadraticFormOperator class
+---------------------------
+
+.. automodule:: qalma.operators.quadratic.quadratic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Builder
+-------
+
+.. automodule:: qalma.operators.quadratic.build
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/operators.rst
+++ b/docs/api/operators.rst
@@ -1,0 +1,55 @@
+qalma.operators
+===============
+
+.. automodule:: qalma.operators
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Base class
+----------
+
+.. automodule:: qalma.operators.basic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Product operators
+-----------------
+
+.. automodule:: qalma.operators.product
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Arithmetic operators
+--------------------
+
+.. automodule:: qalma.operators.arithmetic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+QuTiP-backed operators
+-----------------------
+
+.. automodule:: qalma.operators.qutip
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Simplification
+--------------
+
+.. automodule:: qalma.operators.simplify
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Utilities
+---------
+
+.. automodule:: qalma.operators.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/operators.states.rst
+++ b/docs/api/operators.states.rst
@@ -1,0 +1,55 @@
+qalma.operators.states
+======================
+
+.. automodule:: qalma.operators.states
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Protocols and mixins
+--------------------
+
+.. automodule:: qalma.operators.states.basic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Gibbs states
+------------
+
+.. automodule:: qalma.operators.states.gibbs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Product density operators
+-------------------------
+
+.. automodule:: qalma.operators.states.product
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Mixture density operators
+-------------------------
+
+.. automodule:: qalma.operators.states.arithmetic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+QuTiP density operators
+------------------------
+
+.. automodule:: qalma.operators.states.qutip
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Utilities
+---------
+
+.. automodule:: qalma.operators.states.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/projections.rst
+++ b/docs/api/projections.rst
@@ -1,0 +1,23 @@
+qalma.projections
+=================
+
+.. automodule:: qalma.projections
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+N-body projections
+------------------
+
+.. automodule:: qalma.projections.nbody
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Symmetry projectors
+-------------------
+
+.. automodule:: qalma.projections.symmetries
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/qalma.rst
+++ b/docs/api/qalma.rst
@@ -1,0 +1,52 @@
+qalma
+=====
+
+.. automodule:: qalma
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Top-level helpers
+-----------------
+
+.. autofunction:: qalma.model.build_system
+
+.. autofunction:: qalma.alpsmodels.model_from_alps_xml
+
+.. autofunction:: qalma.alpsmodels.list_models_in_alps_xml
+
+.. autofunction:: qalma.geometry.graph_from_alps_xml
+
+.. autofunction:: qalma.geometry.list_geometries_in_alps_xml
+
+System descriptor
+-----------------
+
+.. automodule:: qalma.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Geometry
+--------
+
+.. automodule:: qalma.geometry
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+ALPS models
+-----------
+
+.. automodule:: qalma.alpsmodels
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Utilities
+---------
+
+.. automodule:: qalma.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/qutip_tools.rst
+++ b/docs/api/qutip_tools.rst
@@ -1,0 +1,15 @@
+qalma.qutip_tools
+=================
+
+.. automodule:: qalma.qutip_tools
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Tools
+-----
+
+.. automodule:: qalma.qutip_tools.tools
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/scalarprod.rst
+++ b/docs/api/scalarprod.rst
@@ -1,0 +1,55 @@
+qalma.scalarprod
+================
+
+.. automodule:: qalma.scalarprod
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Operator bases
+--------------
+
+.. automodule:: qalma.scalarprod.basis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Scalar product builders
+-----------------------
+
+.. automodule:: qalma.scalarprod.build
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Gram matrix
+-----------
+
+.. automodule:: qalma.scalarprod.gram
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Orthogonalization
+-----------------
+
+.. automodule:: qalma.scalarprod.orthogonalize
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Covariance
+----------
+
+.. automodule:: qalma.scalarprod.covar
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Utilities
+---------
+
+.. automodule:: qalma.scalarprod.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ napoleon_preprocess_types = True
 
 # -- Autosummary -------------------------------------------------------------
 
-autosummary_generate = False  # avoids re-indexing symbols already in automodule
+autosummary_generate = True
 
 # -- Todo --------------------------------------------------------------------
 
@@ -123,7 +123,16 @@ nitpick_ignore = [
     ("py:attr", "qalma.operators.states.gibbs.GibbsProductDensityOperator.k_by_site"),
 ]
 
-suppress_warnings = ["ref.python"]
+suppress_warnings = ["ref.python", "misc.highlighting_failure"]
+
+# Register ipython3 as an alias for ipython so nbsphinx notebooks render correctly
+from pygments.lexers import get_lexer_by_name  # noqa: E402
+from sphinx.highlighting import lexers  # noqa: E402
+
+try:
+    lexers["ipython3"] = get_lexer_by_name("ipython")
+except Exception:
+    pass
 
 # SyntaxWarning from LaTeX strings in notebook cell outputs (Python 3.12+)
 warnings.filterwarnings(


### PR DESCRIPTION
- Create docs/api/ with one .rst per public subpackage: qalma, operators, operators.functions, operators.states, operators.quadratic, evolution, meanfield, scalarprod, projections, qutip_tools
- Each page uses automodule for the package __init__ plus individual automodule sections for each submodule
- Fix conf.py: set autosummary_generate = True (was False, which prevented autosummary tables from being generated)
- Suppress misc.highlighting_failure warning and register 'ipython3' as a Pygments lexer alias so notebook code cells render correctly
- Build result: 36 warnings -> 4 (only intersphinx network errors that vanish in a connected environment)