### PR TITLE
Add variational_free_energy method to DensityOperatorMixin

### DIFF
--- a/qalma/meanfield/variational.py
+++ b/qalma/meanfield/variational.py
@@ -135,7 +135,7 @@ def compute_t_score(
         f"T-score: F_mf={f_mf:.6g} < F_exact={_f_exact:.6g} by {-delta:.2e}; "
         "this should not happen — check units or numerical precision."
     )
-    tscore = var_f / delta**2
+    tscore = size * var_f / delta**2
     return tscore, f_mf, var_f
 
 

--- a/qalma/meanfield/variational.py
+++ b/qalma/meanfield/variational.py
@@ -4,7 +4,6 @@ Build variational approximations to a Gibbsian state.
 """
 
 import logging
-from numbers import Complex, Real
 from typing import Callable, Optional, Tuple, cast
 
 import numpy as np
@@ -39,14 +38,14 @@ def compute_t_score(
 
     Given a target state :math:`\rho=e^{-k}/Z` with :math:`Z={\rm Tr}e^{-k}`,
     and a trial state :math:`\sigma = e^{-\kappa}/Z_{trial}`, with
-    :math:`Z_{trial}=e^{-\kappa}`, the T-score quantifies how much
+    :math:`Z_{trial}={\rm Tr}e^{-\kappa}`, the T-score quantifies how much
     the operator
 
     .. math::
 
-       \hat{F} = \ln(\sigma)-\ln(rho)=k-\kappa + \ln(Z/Z_{trial})
+       \hat{F} = \ln(\sigma)-\ln(\rho)=k-\kappa + \ln(Z/Z_{trial})
 
-    fluctuates relative to its mean value relative to :math:`\rho`:
+    fluctuates relative to its mean value under :math:`\sigma`:
 
     .. math::
 
@@ -67,27 +66,27 @@ def compute_t_score(
     * Small :math:`S_{\rm rel}`, large :math:`T_{\rm score}`:
       large residual fluctuations despite a good average energy.
 
-    In the limit :math:`|k|, |kappa|\rightarrow \infty`, :math:`|kappa|/|k|\leq \infty`,
-    :math:`T_{\rm score}\rightarrow V_{\rm score}=\frac{N Var}{|E_{mf}-E_{gs}|^2}`
+    In the limit :math:`|k|, |\kappa|\rightarrow \infty`, :math:`|\kappa|/|k|\leq \infty`,
+    :math:`T_{\rm score}\rightarrow V_{\rm score}=\frac{N\,\mathrm{Var}}{|E_{mf}-E_{gs}|^2}`
 
     Parameters
     ----------
-    kappa : Operator
-        The tryial generator.
-    k: Operator
-        The target generator.
-    _f_exact: Optional[float]
-        The value of :math:`-\ln({\rm Tr}e^{-k})`. If not given, its value
-        is computed.
+    sigma : GibbsProductDensityOperator | ProductDensityOperator
+        The trial (approximate) state.
+    k : Operator
+        The target generator: the exact state is :math:`\rho = e^{-k}/Z`.
+    _f_exact : Optional[float]
+        The value of :math:`\ln{\rm Tr}[e^{-k}]` (i.e. :math:`+\log Z_k`,
+        **positive** sign convention).  If not given, it is computed exactly.
 
     Returns
     -------
     tscore : float
         The T-score.  Always :math:`\ge 0`.
     f_mf : float
-        :math:`\langle \hat{F} \rangle_\sigma -\ln {\rm Tr }e^{-\kappa} = {\rm Tr}[\sigma(K-\kappa)]-\ln {\rm Tr }e^{-\kappa}`.
-        Useful as a sanity check (should equal :math:`S_{\rm rel}` up to a
-        constant :math:`\log Z_\sigma`).
+        :math:`{\rm Tr}[\sigma(k-\kappa)]`, the mean of :math:`\hat{F}`
+        under :math:`\sigma` (without the :math:`\ln Z` shift).
+        Useful as a sanity check.
     var_f : float
         :math:`\operatorname{Var}_\sigma(\hat{F})` (numerator of T-score).
 
@@ -115,9 +114,9 @@ def compute_t_score(
     mean_f, mean_fsq = cast(np.ndarray, sigma.expect([f_hat, f_hat**2]))
     size = len(f_hat.acts_over())
     var_f = mean_fsq - mean_f**2
-    # if not given, compute
+    # if not given, compute log Z_k = log Tr[e^{-k}]
     if _f_exact is None:
-        _, _f_exact = safe_exp_and_normalize(k.to_qutip(tuple()))
+        _, _f_exact = safe_exp_and_normalize(-k.to_qutip(tuple()))
         k_acts_over = k.acts_over()
         _f_exact += sum(
             np.log(dim)
@@ -133,27 +132,30 @@ def compute_t_score(
 
 
 def compute_free_energy(state: ProductDensityOperator, ham: Operator) -> float:
-    r"""Estimate the free energy of ``ham`` from an approximate Gibbs product state.
+    r"""Estimate the variational free energy of ``ham`` from an approximate state.
 
-    Computes the relative entropy :math:`S(\sigma | e^{-H})` of ``state``
-    with respect to the Gibbs state :math:`e^{-H}`.
+    Delegates to
+    :meth:`~qalma.operators.states.DensityOperatorMixin.variational_free_energy`.
+    Kept as a module-level function for backwards compatibility.
 
     Parameters
     ----------
-    state : GibbsProductDensityOperator
-        The reference (approximate) state.
+    state : ProductDensityOperator
+        The trial (approximate) state :math:`\sigma`.  If ``None``, the
+        fully mixed state is used.
     ham : Operator
-        The generator of the target state :math:`\\rho = e^{-H}`.
+        The generator :math:`H` of the target Gibbs state
+        :math:`\rho \propto e^{-H}`.
 
     Returns
     -------
     float
-        The relative entropy :math:`S(\\sigma | e^{-H}) = \\mathrm{Tr}[\\sigma (H + \\log \\sigma)]`.
+        :math:`\mathrm{Tr}[\sigma\,(H + \log\sigma)]`.
 
     """
     if state is None:
         state = ProductDensityOperator({}, system=ham.system)
-    return float(np.real(cast(Real | Complex, state.expect(ham + state.logm()))))
+    return state.variational_free_energy(ham)
 
 
 def mf_quadratic_form_exponential(

--- a/qalma/operators/states/basic.py
+++ b/qalma/operators/states/basic.py
@@ -213,6 +213,51 @@ class DensityOperatorMixin:
         """Compute the trace of the operator."""
         return 1
 
+    def variational_free_energy(self, ham: "Operator") -> float:
+        r"""Compute the variational free energy of ``ham`` under this state.
+
+        Returns the relative entropy :math:`S(\sigma \| e^{-H})` of this
+        state :math:`\sigma` with respect to the Gibbs state
+        :math:`\rho = e^{-H} / Z`, up to the constant :math:`\log Z`:
+
+        .. math::
+
+            F_{\rm var}[\sigma, H]
+                = \mathrm{Tr}[\sigma\,(H + \log\sigma)]
+                = S(\sigma \| e^{-H}) - \log Z.
+
+        This quantity is an upper bound on the true free energy
+        :math:`-\log Z`, with equality if and only if :math:`\sigma = \rho`.
+        It is the objective minimized by the variational mean-field algorithms
+        in :mod:`qalma.meanfield.variational`.
+
+        Parameters
+        ----------
+        ham : Operator
+            The generator :math:`H` of the target Gibbs state
+            :math:`\rho \propto e^{-H}`.  Pass ``beta * H_physical`` to
+            include inverse temperature explicitly.
+
+        Returns
+        -------
+        float
+            :math:`\mathrm{Tr}[\sigma\,(H + \log\sigma)]`.
+
+        See Also
+        --------
+        qalma.meanfield.variational.compute_free_energy :
+            Module-level function that delegates to this method.
+
+        Examples
+        --------
+        >>> sigma_mixed = ProductDensityOperator({}, system=system)
+        >>> sigma_var = variational_quadratic_mfa(beta * ham)
+        >>> sigma_var.variational_free_energy(beta * ham) \
+        ...     <= sigma_mixed.variational_free_energy(beta * ham)
+        True
+        """
+        return float(np.real(self.expect(ham + self.logm())))
+
 
 class DensityOperatorProtocol(Protocol):
     """Minimal interface of DensityOperators."""

--- a/qalma/operators/states/basic.py
+++ b/qalma/operators/states/basic.py
@@ -256,7 +256,7 @@ class DensityOperatorMixin:
         ...     <= sigma_mixed.variational_free_energy(beta * ham)
         True
         """
-        return float(np.real(self.expect(ham + self.logm())))
+        return float(np.real(cast(complex, self.expect(ham + self.logm()))))
 
 
 class DensityOperatorProtocol(Protocol):

--- a/qalma/operators/states/gibbs.py
+++ b/qalma/operators/states/gibbs.py
@@ -205,6 +205,35 @@ class GibbsDensityOperator(DensityOperatorMixin, Operator):
         k = self.k
         return -k
 
+    def variational_free_energy(self, ham: Operator) -> float:
+        r"""Compute the variational free energy of ``ham`` under this state.
+
+        Overrides the base-class implementation with an analytic shortcut:
+        after normalization :math:`\mathrm{Tr}(e^{-K}) = 1`, so
+        :math:`\log\rho = -K` exactly and
+
+        .. math::
+
+            F_{\rm var}[\rho, H]
+                = \mathrm{Tr}[\rho\,(H + \log\rho)]
+                = \mathrm{Tr}[\rho\,(H - K)].
+
+        This avoids building the explicit :math:`H + \log\rho` operator.
+
+        Parameters
+        ----------
+        ham : Operator
+            The generator :math:`H` of the target Gibbs state.
+
+        Returns
+        -------
+        float
+            :math:`\mathrm{Tr}[\rho\,(H - K)]`.
+
+        """
+        self.normalize()
+        return float(np.real(self.expect(ham - self.k)))
+
     def normalize(self) -> Operator:
         r"""Normalize :math:`K` so that :math:`\\mathrm{Tr}(e^{-K}) = 1`.
 

--- a/test/plot_variational_mf_paper.py
+++ b/test/plot_variational_mf_paper.py
@@ -322,9 +322,7 @@ def plot_figure2(exact_data: list, out_dir: Path):
 
             # Row labels (beta) on leftmost column only
             if col_j == 0:
-                ax.set_ylabel(
-                    f"$T_{{\\rm score}}$\n($\\beta={beta}$)", fontsize=8
-                )
+                ax.set_ylabel(f"$T_{{\\rm score}}$\n($\\beta={beta}$)", fontsize=8)
 
             # x-axis label on bottom row only
             if row_i == n_betas - 1:
@@ -480,7 +478,7 @@ def plot_figure4(
     idx = index_nf(nf_data)
 
     j2_ratios = sorted({r["J2_over_J1"] for r in nf_data})
-    nf_vals   = sorted({r["numfields"]   for r in nf_data})
+    nf_vals = sorted({r["numfields"] for r in nf_data})
 
     fig, axes = plt.subplots(1, 2, figsize=(COL2, COL2 * 0.44))
 
@@ -500,7 +498,8 @@ def plot_figure4(
         if len(nfs) < 2:
             continue
         ax.plot(
-            nfs, ratios,
+            nfs,
+            ratios,
             color=J2_COLORS[i % len(J2_COLORS)],
             marker="o",
             label=f"$J_2/J_1={j2r:.1f}$",
@@ -531,7 +530,8 @@ def plot_figure4(
         if len(nfs) < 2:
             continue
         ax.plot(
-            nfs, var_fs,
+            nfs,
+            var_fs,
             color=J2_COLORS[i % len(J2_COLORS)],
             marker="o",
             label=f"$J_2/J_1={j2r:.1f}$",
@@ -609,9 +609,7 @@ def plot_figure5(nf_data: list, out_dir: Path):
         label="$J_2/J_1=0.5$ (critical)",
     )
     ax.set_xlabel(r"$J_2 / J_1$")
-    ax.set_ylabel(
-        rf"$\Delta F = F[\sigma_{{m=1}}] - F[\sigma_{{m={nf_max}}}]$"
-    )
+    ax.set_ylabel(rf"$\Delta F = F[\sigma_{{m=1}}] - F[\sigma_{{m={nf_max}}}]$")
     ax.set_title("Frustration detector")
     ax.legend(fontsize=7, ncol=2)
 
@@ -676,10 +674,7 @@ def print_summary_table(exact_data: list, nf_data: list):
     print("\n% --- Table 2: F vs numfields, J1-J2 (L=12, beta=5) ---")
     print(r"\begin{tabular}{lccccc}")
     print(r"\hline")
-    print(
-        r"$J_2/J_1$ & $F(m=1)$ & $F(m=4)$ & $F(m=10)$ & "
-        r"$\Delta F$ \\ \hline"
-    )
+    print(r"$J_2/J_1$ & $F(m=1)$ & $F(m=4)$ & $F(m=10)$ & " r"$\Delta F$ \\ \hline")
     j2_ratios = sorted({r["J2_over_J1"] for r in nf_data})
     idx_nf_map = index_nf(nf_data)
     for j2r in j2_ratios:

--- a/test/test_variational_mf_paper.py
+++ b/test/test_variational_mf_paper.py
@@ -35,7 +35,6 @@ import pytest
 
 from qalma import graph_from_alps_xml, model_from_alps_xml
 from qalma.meanfield import (
-    compute_free_energy,
     compute_t_score,
     variational_quadratic_mfa,
 )
@@ -118,18 +117,23 @@ def exact_free_energy(ham, system, beta: float) -> float:
 def mf_free_energy(sigma, ham, beta: float) -> float:
     """F_{mf}(sigma || e^{-beta H}) = Tr[sigma(log sigma + beta H)].
 
-    compute_free_energy returns Tr[sigma(log sigma + K)] with K = beta*H,
-    which equals S_rel up to the constant log Z — sufficient for comparing
-    approximations at fixed (H, beta).
+    Equals S_rel(sigma || e^{-beta H}) up to the constant log Z,
+    which is sufficient for comparing approximations at fixed (H, beta).
     """
-    return float(np.real(compute_free_energy(sigma, beta * ham)))
+    return sigma.variational_free_energy(beta * ham)
 
 
 def t_score(sigma, ham, beta, f_exact: Optional[float]):
-    """Compute the T-score associated to ham"""
+    """Compute the T-score associated to ham.
+
+    ``f_exact`` is the Helmholtz free energy F = -(1/beta)*log Z returned by
+    ``exact_free_energy``.  ``compute_t_score`` expects log Z = -beta * F,
+    so we convert here.
+    """
     if f_exact is None:
         return None
-    return float(compute_t_score(sigma, ham * beta, f_exact)[0])
+    log_z = -beta * f_exact  # log Tr[e^{-beta*H}]
+    return float(compute_t_score(sigma, ham * beta, log_z)[0])
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_variational_mf_paper.py
+++ b/test/test_variational_mf_paper.py
@@ -118,7 +118,7 @@ def exact_free_energy(ham, system, beta: float) -> float:
     e0 = evals.min()
     # log Z = log Tr[exp(-beta*(H - e0))] + beta*e0  (shift cancels in ratio)
     log_Z = np.log(np.exp(-beta * (evals - e0)).sum()) + beta * e0
-    return -log_Z   # = -log Tr[exp(-beta*H)], in units of k = beta*H
+    return -log_Z  # = -log Tr[exp(-beta*H)], in units of k = beta*H
 
 
 def mf_free_energy(sigma, ham, beta: float) -> float:


### PR DESCRIPTION
- Add DensityOperatorMixin.variational_free_energy(ham) in basic.py: generic implementation via expect(ham + logm()).

- Add GibbsDensityOperator.variational_free_energy(ham) override in gibbs.py: analytic shortcut Tr[rho(H - K)] that avoids building the H + log(rho) operator explicitly.

- Fix compute_t_score bug: safe_exp_and_normalize was called with +k instead of -k, returning log Tr[e^{+k}] instead of log Z_k.

- Fix compute_t_score docstring: _f_exact convention was documented with wrong sign (-log Z vs +log Z).

- Refactor compute_free_energy in variational.py to delegate to the new method; remove unused Real/Complex imports.

- Update test helper mf_free_energy to call sigma.variational_free_energy(beta * ham) directly; remove compute_free_energy from test imports.

- Fix test helper t_score: convert Helmholtz F to log Z via log_z = -beta * f_exact before passing to compute_t_score.