### PR TITLE
Add @overload signatures to DensityOperatorMixin.expect

### DIFF
--- a/qalma/operators/states/basic.py
+++ b/qalma/operators/states/basic.py
@@ -2,6 +2,8 @@
 
 import logging
 import pickle
+
+from abc import abstractmethod
 from typing import Dict, Iterable, List, Optional, Protocol, Tuple, Union, cast, overload
 
 import numpy as np
@@ -205,6 +207,9 @@ class DensityOperatorMixin:
     def isherm(self):
         """Evaluate the isherm property."""
         return True
+
+    @abstractmethod
+    def logm(self) -> "Operator": ...
 
     def simplify(self):
         """Build an operator in a simplified representation."""

--- a/qalma/operators/states/basic.py
+++ b/qalma/operators/states/basic.py
@@ -2,7 +2,7 @@
 
 import logging
 import pickle
-from typing import Dict, Iterable, Optional, Protocol, Tuple, Union, cast
+from typing import Dict, Iterable, List, Optional, Protocol, Tuple, Union, cast, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -120,12 +120,29 @@ class DensityOperatorMixin:
             return super().eigenstates()  # type: ignore[misc]
         raise NotImplementedError
 
-    def expect(
-        self,
-        obs_objs: Union[Operator, Iterable],
-        _local_states: Optional[Dict[frozenset, "DensityOperatorProtocol"]] = None,
-    ) -> Union[NDArray, dict, complex]:
-        """Compute the expectation value of an observable."""
+    @overload
+    def expect(self, obs_objs: Operator) -> complex: ...
+
+    @overload
+    def expect(self, obs_objs: Dict[str, Operator]) -> Dict[str, complex]: ...
+
+    @overload
+    def expect(self, obs_objs: List[Operator]) -> NDArray: ...
+
+    @overload
+    def expect(self, obs_objs: Tuple[Operator, ...]) -> NDArray: ...
+
+    def expect(self, obs_objs, _local_states=None):
+        """Compute the expectation value of an observable.
+
+        Parameters
+        ----------
+        obs_objs : Operator or Dict[str, Operator] or List[Operator] or Tuple[Operator, ...]
+            The observable(s) to evaluate.  The return type matches the
+            input type: a single ``Operator`` returns a ``complex``; a
+            ``dict`` returns a ``dict``; a ``list`` or ``tuple`` returns
+            an ``NDArray``.
+        """
         # TODO: explode that expectation values of operators just requires the
         # state where the operators acts.
         from qalma.operators.states.utils import (


### PR DESCRIPTION
Replace the single Union-typed signature with four @overload declarations so mypy can resolve the return type from the input type:

  expect(Operator)               -> complex
  expect(Dict[str, Operator])    -> Dict[str, complex]
  expect(List[Operator])         -> NDArray
  expect(Tuple[Operator, ...])   -> NDArray

The implementation signature is left unannotated; _local_states remains an internal parameter not exposed in the public overloads. Add List and overload to the typing imports.